### PR TITLE
Add transcript pipeline, CLI utility, and FastAPI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# ios-yt-transcript
+# iOS YouTube Transcript Toolkit
+
+This repository contains a lightweight Python service and command-line utilities
+for turning a YouTube share link into a plain-text transcript. The setup is
+intended to be triggered from an iOS Shortcut that shares the transcript back to
+your clipboard.
+
+## Features
+
+1. **Transcript pipeline** – Convert a YouTube URL (or video id) into a
+   newline-separated transcript without timestamps.
+2. **Command-line helper** – Quickly test the transcript retrieval from a
+   terminal before wiring it into Shortcuts.
+3. **FastAPI server** – A simple endpoint you can self-host on your home
+   network. The iOS Shortcut POSTs the shared YouTube URL and receives the
+   transcript in response.
+4. **Shortcut integration outline** – Step-by-step instructions to glue the
+   pieces together on iOS.
+
+## Getting Started
+
+### 1. Install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2. Fetch a transcript from the command line
+
+```bash
+python scripts/get_transcript.py "https://youtu.be/dQw4w9WgXcQ"
+```
+
+Use `--languages` if you want to prefer specific caption languages, for example
+`--languages en en-US`.
+
+### 3. Run the server locally
+
+```bash
+uvicorn server.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Send a request to the API:
+
+```bash
+curl -X POST \
+  http://localhost:8000/transcript \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://youtu.be/dQw4w9WgXcQ"}'
+```
+
+The response includes a JSON payload with the transcript text:
+
+```json
+{"transcript": "..."}
+```
+
+### 4. Build the iOS Shortcut
+
+1. Create a new Shortcut and add the **Share Sheet** trigger for YouTube.
+2. Add a **Get Contents of URL** action:
+   - Method: `POST`
+   - URL: `http://<your-server-ip>:8000/transcript`
+   - Request Body: JSON with a field `url` equal to the Shortcut input.
+3. Add a **Get Dictionary Value** action to pull out the `transcript` field.
+4. Finish with a **Copy to Clipboard** action.
+
+Now, when you tap **Share → Your Shortcut** in the YouTube app, the transcript
+will be fetched by your server and placed on the clipboard automatically.
+
+## Testing
+
+Run the unit tests to verify the URL parsing logic:
+
+```bash
+pytest
+```
+
+## Notes
+
+- The service uses [`youtube-transcript-api`](https://pypi.org/project/youtube-transcript-api/),
+  which works for videos with public transcripts. Private videos or those
+  without captions will raise an error.
+- To harden the service for public exposure, add authentication and rate
+  limiting. For home-network usage triggered from Shortcuts, the current setup
+  keeps things simple.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[yaml]
+youtube-transcript-api
+pydantic

--- a/scripts/get_transcript.py
+++ b/scripts/get_transcript.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Fetch and print a transcript for a YouTube video."""
+
+import argparse
+import sys
+
+from transcript_service import TranscriptFetcher, TranscriptError
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="YouTube video URL or id")
+    parser.add_argument(
+        "--languages",
+        nargs="*",
+        default=None,
+        help="Preferred transcript languages, e.g. en en-US",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    fetcher = TranscriptFetcher(preferred_languages=args.languages)
+
+    try:
+        transcript = fetcher.fetch(args.url)
+    except TranscriptError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(transcript)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,27 @@
+"""FastAPI server that returns YouTube transcripts for a provided URL."""
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from transcript_service import TranscriptError, TranscriptFetcher
+
+app = FastAPI(title="YouTube Transcript Service")
+
+
+class TranscriptRequest(BaseModel):
+    url: str
+    languages: list[str] | None = None
+
+
+class TranscriptResponse(BaseModel):
+    transcript: str
+
+
+@app.post("/transcript", response_model=TranscriptResponse)
+async def get_transcript(payload: TranscriptRequest) -> TranscriptResponse:
+    fetcher = TranscriptFetcher(preferred_languages=payload.languages)
+    try:
+        transcript_text = fetcher.fetch(payload.url)
+    except TranscriptError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return TranscriptResponse(transcript=transcript_text)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,24 @@
+from transcript_service.pipeline import extract_video_id
+
+
+def test_extract_standard_watch_url():
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert extract_video_id(url) == "dQw4w9WgXcQ"
+
+
+def test_extract_short_url():
+    url = "https://youtu.be/dQw4w9WgXcQ"
+    assert extract_video_id(url) == "dQw4w9WgXcQ"
+
+
+def test_extract_with_query_params():
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=10"
+    assert extract_video_id(url) == "dQw4w9WgXcQ"
+
+
+def test_extract_from_id():
+    assert extract_video_id("dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+
+def test_extract_invalid_returns_none():
+    assert extract_video_id("not-a-url") is None

--- a/transcript_service/__init__.py
+++ b/transcript_service/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for retrieving YouTube video transcripts."""
+
+from .pipeline import TranscriptError, TranscriptFetcher, extract_video_id
+
+__all__ = ["TranscriptFetcher", "TranscriptError", "extract_video_id"]

--- a/transcript_service/pipeline.py
+++ b/transcript_service/pipeline.py
@@ -1,0 +1,82 @@
+"""Core pipeline utilities for fetching YouTube transcripts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.parse import parse_qs, urlparse
+
+_YOUTUBE_REGEX = re.compile(
+    r"(?:https?://)?(?:www\.|m\.)?(?:youtube\.com|youtu\.be)/(?:watch\?v=)?([\w-]{11})"
+)
+
+
+class TranscriptError(RuntimeError):
+    """Raised when the transcript cannot be retrieved."""
+
+
+@dataclass
+class TranscriptFetcher:
+    """Fetch a transcript for a given YouTube URL."""
+
+    preferred_languages: Optional[List[str]] = None
+
+    def fetch(self, video_url: str) -> str:
+        """Return a transcript without timestamps for the provided video URL.
+
+        Args:
+            video_url: The YouTube video URL or video id.
+
+        Returns:
+            The transcript text with each caption entry separated by a newline.
+        """
+
+        video_id = extract_video_id(video_url)
+        if not video_id:
+            raise TranscriptError(f"Unable to determine video id from: {video_url}")
+
+        try:
+            from youtube_transcript_api import (
+                NoTranscriptFound,
+                TranscriptsDisabled,
+                YouTubeTranscriptApi,
+            )
+        except ImportError as exc:
+            raise TranscriptError('youtube-transcript-api is required to fetch transcripts') from exc
+
+        try:
+            transcript = YouTubeTranscriptApi.get_transcript(
+                video_id, languages=self.preferred_languages
+            )
+        except (TranscriptsDisabled, NoTranscriptFound) as exc:
+            raise TranscriptError("Transcript is unavailable for this video") from exc
+        except Exception as exc:  # pragma: no cover - pass through unexpected errors
+            raise TranscriptError("Failed to fetch transcript") from exc
+
+        lines = [entry["text"].strip() for entry in transcript if entry["text"].strip()]
+        return "\n".join(lines)
+
+
+def extract_video_id(value: str) -> Optional[str]:
+    """Extract the YouTube video id from a URL or return the value if it's already an id."""
+
+    value = value.strip()
+    if not value:
+        return None
+
+    if len(value) == 11 and re.fullmatch(r"[\w-]{11}", value):
+        return value
+
+    parsed = urlparse(value)
+    if parsed.query:
+        query_params = parse_qs(parsed.query)
+        video_id = query_params.get("v", [None])[0]
+        if video_id:
+            return video_id
+
+    match = _YOUTUBE_REGEX.search(value)
+    if match:
+        return match.group(1)
+
+    return None


### PR DESCRIPTION
## Summary
- add a reusable transcript fetching pipeline with error handling
- create a CLI helper script and FastAPI endpoint for returning transcripts
- document setup steps, shortcut integration, and include URL parsing tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e150fcfc688328a39dff50e90e7a50